### PR TITLE
Make the version number consistent with the § about file order

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ with Symfony2 yet, follow the
 Through [Composer](http://getcomposer.org), add to composer.json:
 
     "require": {
-        "khepin/yaml-fixtures-bundle": "0.7.*"
+        "khepin/yaml-fixtures-bundle": "~0.8.1"
     }
 
 Then register the bundle in `AppKernel.php` it's better to only register it in


### PR DESCRIPTION
Looking at the changelog, it looks like the feature available in the "Configuration" § won't be available if someone uses 1.7.*
