### PR TITLE
Change  cast value in case other name than AppKernel

### DIFF
--- a/Loader/YamlLoader.php
+++ b/Loader/YamlLoader.php
@@ -6,6 +6,7 @@ use Khepin\YamlFixturesBundle\Fixture\YamlAclFixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\HttpKernel\Kernel;
 
 class YamlLoader
 {
@@ -44,7 +45,7 @@ class YamlLoader
      */
     private $directory;
 
-    public function __construct(\AppKernel $kernel, $bundles, $directory)
+    public function __construct(Kernel $kernel, $bundles, $directory)
     {
         $this->bundles = $bundles;
         $this->kernel = $kernel;


### PR DESCRIPTION
In some project, we can rename the AppKernel in something more special and in this case we can't use your bundle anymore.
So i updated it changing the cast of the $kernel value from \AppKernel to Kernel in order to have something that always work.

Thanks
