### PR TITLE
Load fixture files recursively

### DIFF
--- a/Loader/YamlLoader.php
+++ b/Loader/YamlLoader.php
@@ -87,13 +87,39 @@ class YamlLoader
     protected function loadFixtureFiles()
     {
         foreach ($this->bundles as $bundle) {
-            $file = '*';
+            $file = null;
             if (strpos($bundle, '/')) {
                 list($bundle, $file) = explode('/', $bundle);
             }
+
             $path = $this->kernel->locateResource('@' . $bundle);
-            $files = glob($path . $this->directory . '/'.$file.'.yml');
-            $this->fixture_files = array_unique(array_merge($this->fixture_files, $files));
+            $path .= $this->directory;
+
+            $bundleFiles = [];
+            if (!empty($file)) {
+                $bundleFiles = glob($path . '/'.$file.'.yml');
+            } else {
+                $directory = new \RecursiveDirectoryIterator($path);
+                $iterator = new \RecursiveIteratorIterator($directory);
+                $files = new \RegexIterator($iterator, '/^.+\.yml$/i', \RecursiveRegexIterator::GET_MATCH);
+
+                foreach ($files as $file) {
+                    $bundleFiles[] = $file[0];
+                }
+            }
+
+            uasort($bundleFiles, function($a, $b) {
+                $a = basename($a);
+                $b = basename($b);
+
+                if ($a == $b) {
+                    return 0;
+                }
+
+                return ($a < $b) ? -1 : 1;
+            });
+
+            $this->fixture_files = array_unique(array_merge($this->fixture_files, $bundleFiles));
         }
     }
 
@@ -145,7 +171,7 @@ class YamlLoader
 
         // Instanciate purger and executor
         $persister = $this->getPersister($persistence);
-        $entityManagers = ($databaseName) 
+        $entityManagers = ($databaseName)
             ? array($persister->getManager($databaseName))
             : $persister->getManagers();
 


### PR DESCRIPTION
Hi, i've changed the YamlLoader to be able to load the fixture files from the directory recursively.
In addition, the files of a bundle will be sorted by filename. This makes it possible to create an order in which the files will be loaded.
.
├── 000_books.yml
├── 001_users.yml
├── 002_reviews.yml
├── test1
│   ├── 001_additional_users_for_test1.yml
│   └── 002_additional_reviews_for_test1.yml
└── test2
    └── 000_additional_books_for_test2.yml

This directory would be loaded in the following order:
1. 000_books.yml
2. 000_additional_books_for_test2.yml
3. 001_users.yml
4. 001_additional_users_for_test1.yml
5. 002_reviews.yml
6. 002_additional_reviews_for_test1.yml

This loading strategy makes it easier to maintain large sets of fixture data.